### PR TITLE
Move security policy to own file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -309,8 +309,3 @@ mind.
     submitting PRs to fix one typo, one warning,etc. We recommend fixing the
     same issue at the file level at least (e.g.: fix all typos in a file, fix
     all compiler warnings in a file, etc.)
-
-## Security vulnerability reports
-
-Since TF-Keras is the high-level API of TensorFlow 2, TF-Keras follows same security practices as TensorFlow.
-For details on guidelines on vulnerabilities and reporting them, you can refer [Using TensorFlow Securely](https://github.com/tensorflow/tensorflow/blob/master/SECURITY.md). 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,4 @@
+## Security vulnerability reports
+
+Since Keras is the high-level API of TensorFlow 2, Keras follows the same security practices as TensorFlow.
+For details on guidelines on vulnerabilities and how to report them, you can refer to [Using TensorFlow Securely](https://github.com/tensorflow/tensorflow/blob/master/SECURITY.md). 


### PR DESCRIPTION
Fixes https://github.com/keras-team/tf-keras/issues/3.

This PR moves Keras' security policy to its own dedicated file for increased visibility.