### PR TITLE
Update example code in timeseries_dataset.py

### DIFF
--- a/tf_keras/utils/timeseries_dataset.py
+++ b/tf_keras/utils/timeseries_dataset.py
@@ -118,7 +118,8 @@ def timeseries_dataset_from_array(
         input_data, targets, sequence_length=sequence_length)
     for batch in dataset:
       inputs, targets = batch
-      assert np.array_equal(inputs[0], data[:sequence_length])  # First sequence: steps [0-9]
+      # First sequence: steps [0-9]
+      assert np.array_equal(inputs[0], data[:sequence_length])
       # Corresponding target: step 10
       assert np.array_equal(targets[0], data[sequence_length])
       break
@@ -126,7 +127,6 @@ def timeseries_dataset_from_array(
     for batch in dataset.as_numpy_iterator():
       input, label  = batch
       print(f"Input:{input}, target:{label}")
-    
     ```
 
     Example 3: Temporal regression for many-to-many architectures.

--- a/tf_keras/utils/timeseries_dataset.py
+++ b/tf_keras/utils/timeseries_dataset.py
@@ -111,11 +111,12 @@ def timeseries_dataset_from_array(
 
     ```python
     data = tf.range(15)
-    sequence_length =10
+    sequence_length = 10
     input_data = data[:]
     targets = data[sequence_length:]
     dataset = tf.keras.utils.timeseries_dataset_from_array(
-        input_data, targets, sequence_length=sequence_length)
+        input_data, targets, sequence_length=sequence_length
+    )
     for batch in dataset:
       inputs, targets = batch
       # First sequence: steps [0-9]
@@ -125,7 +126,7 @@ def timeseries_dataset_from_array(
       break
     # To view the generated dataset
     for batch in dataset.as_numpy_iterator():
-      input, label  = batch
+      input, label = batch
       print(f"Input:{input}, target:{label}")
     ```
 

--- a/tf_keras/utils/timeseries_dataset.py
+++ b/tf_keras/utils/timeseries_dataset.py
@@ -110,16 +110,23 @@ def timeseries_dataset_from_array(
     timesteps to predict the next timestep, you would use:
 
     ```python
-    input_data = data[:-10]
-    targets = data[10:]
+    data = tf.range(15)
+    sequence_length =10
+    input_data = data[:]
+    targets = data[sequence_length:]
     dataset = tf.keras.utils.timeseries_dataset_from_array(
-        input_data, targets, sequence_length=10)
+        input_data, targets, sequence_length=sequence_length)
     for batch in dataset:
       inputs, targets = batch
-      assert np.array_equal(inputs[0], data[:10])  # First sequence: steps [0-9]
+      assert np.array_equal(inputs[0], data[:sequence_length])  # First sequence: steps [0-9]
       # Corresponding target: step 10
-      assert np.array_equal(targets[0], data[10])
+      assert np.array_equal(targets[0], data[sequence_length])
       break
+    # To view the generated dataset
+    for batch in dataset.as_numpy_iterator():
+      input, label  = batch
+      print(f"Input:{input}, target:{label}")
+    
     ```
 
     Example 3: Temporal regression for many-to-many architectures.


### PR DESCRIPTION
I have gone through the example-2 in the TF documentation of [keras.utils.timeseries_dataset_from_array](https://www.tensorflow.org/api_docs/python/tf/keras/utils/timeseries_dataset_from_array). With existing code we can only generate one batch of dataset.In TF forum one of the user raised concern that users may confuse why we are using `input_data = data[:-10]` as it can generate only one batch and there will be loss of data and users may confuse `-10` as `sequence_length` here. Though the intention in the example is to demo on generating batches of data using the API,Its better to use `input_data = data[:]` to avoid confusion and also it give correct demo to generate the total possible no of batches without loss of data.

Also I am adding the `sequence_length` as variable in the code to avoid hard coding in the data indexing which will make it better understandable.

Thanks!