### PR TITLE
Formatting of python code fencing for SidecarEvaluatorModelExport

### DIFF
--- a/tf_keras/utils/sidecar_evaluator.py
+++ b/tf_keras/utils/sidecar_evaluator.py
@@ -382,6 +382,7 @@ class SidecarEvaluatorModelExport(ModelCheckpoint):
     sidecar_evaluator.start()
     # Model weights are saved if evaluator deems it's the best seen so far.
     ```
+    
     Args:
         export_filepath: Path where best models should be saved by this
           `SidecarEvaluatorModelExport` callback. Epoch formatting options, such

--- a/tf_keras/utils/sidecar_evaluator.py
+++ b/tf_keras/utils/sidecar_evaluator.py
@@ -381,7 +381,7 @@ class SidecarEvaluatorModelExport(ModelCheckpoint):
     )
     sidecar_evaluator.start()
     # Model weights are saved if evaluator deems it's the best seen so far.
-
+    ```
     Args:
         export_filepath: Path where best models should be saved by this
           `SidecarEvaluatorModelExport` callback. Epoch formatting options, such


### PR DESCRIPTION
In the tensorflow.org the documentation page of tf.keras.callbacks.SidecarEvaluatorModelExport showing content of raw HTML pages. The reason may be that the Python code fence was not closed causing the page view breaking. Hence correcting the mistake.

May Fixes TF ticket [#61375](https://github.com/tensorflow/tensorflow/issues/61375)