### PR TITLE
Adding more details on separator Args for CSVlogger

### DIFF
--- a/tf_keras/callbacks.py
+++ b/tf_keras/callbacks.py
@@ -3164,6 +3164,7 @@ class CSVLogger(Callback):
     Args:
         filename: Filename of the CSV file, e.g. `'run/log.csv'`.
         separator: String used to separate elements in the CSV file.
+                   Separator string ("delimiter") must be a 1-character string.
         append: Boolean. True: append if file exists (useful for continuing
             training). False: overwrite existing file.
     """

--- a/tf_keras/callbacks.py
+++ b/tf_keras/callbacks.py
@@ -3164,7 +3164,7 @@ class CSVLogger(Callback):
     Args:
         filename: Filename of the CSV file, e.g. `'run/log.csv'`.
         separator: String used to separate elements in the CSV file.
-        Separator string ("delimiter") must be a 1-character string.
+            Separator string ("delimiter") must be a 1-character string.
         append: Boolean. True: append if file exists (useful for continuing
             training). False: overwrite existing file.
     """

--- a/tf_keras/callbacks.py
+++ b/tf_keras/callbacks.py
@@ -3164,7 +3164,7 @@ class CSVLogger(Callback):
     Args:
         filename: Filename of the CSV file, e.g. `'run/log.csv'`.
         separator: String used to separate elements in the CSV file.
-                   Separator string ("delimiter") must be a 1-character string.
+        Separator string ("delimiter") must be a 1-character string.
         append: Boolean. True: append if file exists (useful for continuing
             training). False: overwrite existing file.
     """


### PR DESCRIPTION
Currently the Args Separator  doesn't explain to take only the 1-char string as delimiter which may cause 'TypeError' if user uses more than 1-char string delimiter.

Please refer to this replicated [gist](https://colab.sandbox.google.com/gist/RenuPatelGoogle/1e6d7d51f38f80ef33614637997defd1/tf-keras-callbacks-csvlogger.ipynb) for the reference on the same.