### PR TITLE
Updated the Custom callback URL with text name in callbacks.Callback API

### DIFF
--- a/tf_keras/callbacks.py
+++ b/tf_keras/callbacks.py
@@ -629,8 +629,8 @@ class Callback:
     inference lifecycle.
 
     To create a custom callback, subclass `keras.callbacks.Callback` and
-    override the method associated with the stage of interest. See
-    https://www.tensorflow.org/guide/tf_keras/custom_callback for more
+    override the method associated with the stage of interest. See the 
+    [Custom callback](https://www.tensorflow.org/guide/tf_keras/custom_callback) for more
     information.
 
     Example:

--- a/tf_keras/callbacks.py
+++ b/tf_keras/callbacks.py
@@ -630,8 +630,8 @@ class Callback:
 
     To create a custom callback, subclass `keras.callbacks.Callback` and
     override the method associated with the stage of interest. See the 
-    [Custom callback](https://www.tensorflow.org/guide/tf_keras/custom_callback) for more
-    information.
+    [Custom callback](https://www.tensorflow.org/guide/keras/custom_callback)
+    for more information.
 
     Example:
 

--- a/tf_keras/callbacks.py
+++ b/tf_keras/callbacks.py
@@ -629,7 +629,7 @@ class Callback:
     inference lifecycle.
 
     To create a custom callback, subclass `keras.callbacks.Callback` and
-    override the method associated with the stage of interest. See the 
+    override the method associated with the stage of interest. See the
     [Custom callback](https://www.tensorflow.org/guide/keras/custom_callback)
     for more information.
 


### PR DESCRIPTION
Wrapped the Custom callback URL with the proper defining text to be in clickable format.

Earlier it was in this format : "See https://www.tensorflow.org/guide/keras/custom_callback for more information."

Changed to : "See the [Custom callback](https://www.tensorflow.org/guide/keras/custom_callback) for more information."

