### PR TITLE
Add dependabot to monitor GitHub Actions and Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    ignore:
+      - dependency-name: "protobuf"  # see comment in requirements.txt
+    groups:
+      python:
+        patterns:
+          - "*"

--- a/.github/workflows/auto-assignment.yaml
+++ b/.github/workflows/auto-assignment.yaml
@@ -16,8 +16,8 @@ jobs:
   welcome:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/github-script@v6
+      - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
         with:
           script: |
             const script = require('./\.github/workflows/scripts/auto-assignment.js')

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,7 +12,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get pip cache dir
         id: pip-cache
@@ -20,7 +20,7 @@ jobs:
           python -m pip install --upgrade pip setuptools
           echo "::set-output name=dir::$(pip cache dir)"
       - name: pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
@@ -34,7 +34,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v5
         with:
           commit-message: format the code
           committer: A. Unique TensorFlower <gardener@tensorflow.org>

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     name: Check the code format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get pip cache dir
         id: pip-cache
@@ -21,7 +21,7 @@ jobs:
           python -m pip install --upgrade pip setuptools
           echo "::set-output name=dir::$(pip cache dir)"
       - name: pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}

--- a/.github/workflows/pull_workflow.yaml
+++ b/.github/workflows/pull_workflow.yaml
@@ -12,8 +12,8 @@ jobs:
   welcome:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/github-script@v6
+      - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
         with:
           script: |
             const script = require('./\.github/workflows/scripts/pull_workflow.js')

--- a/.github/workflows/stale-issues-pr.yml
+++ b/.github/workflows/stale-issues-pr.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Awaiting response issues
-        uses: actions/stale@v5
+        uses: actions/stale@v9
         with:
           days-before-issue-stale: 14
           days-before-issue-close: 14
@@ -31,7 +31,7 @@ jobs:
           close-pr-message: "This PR was closed because it has been inactive for 28 days. Please reopen if you'd like to work on this further."
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Contribution issues
-        uses: actions/stale@v5
+        uses: actions/stale@v9
         with:
           days-before-issue-stale: 180
           days-before-issue-close: 365

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # The rest of the packages are mostly used for testing purpose.
 pandas
 pydot
-scipy ~= 1.9.2
+scipy ~= 1.11.4
 # Remove once both TensorFlow and TF-Keras nightly builds pass.
 # Temporarily enforce 3.20.3 version, as the only version which is compatible
 # with both new and old protobuf stubs. This is needed to resolve
@@ -13,7 +13,7 @@ tf-nightly
 portpicker
 pyyaml
 Pillow
-numpy ~= 1.24.3  # Sync with the numpy version used in TF
-black==22.3.0
-isort==5.10.1
-flake8==4.0.1
+numpy ~= 1.26.2  # Sync with the numpy version used in TF
+black==23.12.1
+isort==5.13.2
+flake8==6.1.0


### PR DESCRIPTION
Hey, it's Pedro (see https://github.com/keras-team/tf-keras/pull/683) and I'm back with another security suggestion.

This PR is very similar to the ones I sent to [Keras](https://github.com/keras-team/keras/pull/18834) and [KerasCV](https://github.com/keras-team/keras-cv/pull/2259). It configures Dependabot to monitor the GitHub Actions used in TF-Keras' workflows, as well as its Python dependencies.

I've configured Dependabot to send a single monthly PR (every 1st of the month) updating all dependencies in each ecosystem (see the PRs in my fork: https://github.com/pnacht/tf-keras/pull/1 and https://github.com/pnacht/tf-keras/pull/3).

I have taken the liberty of merging those dependabot PRs into this one so you don't receive such PRs right after merging this one.

Note that I've told Dependabot to ignore `protobuf`, due to the issue mentioned here:

https://github.com/keras-team/tf-keras/blob/6add81a967a830418b1507ac99ddba2d4e43a62b/requirements.txt#L6-L11

However, it will update numpy, despite the comment in the requirements file (shown below), since TF itself is already using a more recent version of numpy.

https://github.com/keras-team/tf-keras/blob/6add81a967a830418b1507ac99ddba2d4e43a62b/requirements.txt#L16

TF's version is 2.26.1 (see [its requirements file](https://github.com/tensorflow/tensorflow/blob/aa216a30ebaa1f545d7f9e5bcee3c9405a5612a1/requirements_lock_3_12.txt#L372), last updated two months ago), while Dependabot is updating TF-Keras to 2.26.2 (released one month ago). This version is likely more similar to the version used by TF, but let me know if you'd rather Dependabot ignore this dependency as well, ensuring TF-Keras' version is always equal to or older than the one used by TF.

(Following https://github.com/keras-team/keras/issues/18833#issuecomment-1828743533, I haven't sent an issue for this. Let me know if TF-Keras prefers always having an accompanying issue to discuss my contributions).