### PR TITLE
Critical typo: squeeze the y_pred tensor even when it’s the same rank and shape as the y_pred tensor should be == instead of !=

### DIFF
--- a/tf_keras/utils/losses_utils.py
+++ b/tf_keras/utils/losses_utils.py
@@ -195,7 +195,7 @@ def squeeze_or_expand_dimensions(y_pred, y_true=None, sample_weight=None):
         y_true_rank = y_true_shape.ndims
         if (y_true_rank is not None) and (y_pred_rank is not None):
             # Use static rank for `y_true` and `y_pred`.
-            if (y_pred_rank - y_true_rank != 1) or y_pred_shape[-1] == 1:
+            if (y_pred_rank - y_true_rank == 1) or y_pred_shape[-1] == 1:
                 y_true, y_pred = remove_squeezable_dimensions(y_true, y_pred)
         else:
             # Use dynamic rank.


### PR DESCRIPTION
Current behavior will squeeze the y_pred tensor even when it’s the same rank and shape as the y_pred tensor.

The issue is that the code is written wrong. Read the code comments and what it’s supposed to do (only squeeze when the ranks differ by exactly 1 and not squeeze for situations of equal rank). Yet the code’s if statements will squeeze whenever the ranks are equal, which is wrong from what I can tell.

the line: `if (y_pred_rank - y_true_rank != 1) or y_pred_shape[-1] == 1:`  should be:
`if (y_pred_rank - y_true_rank == 1) or y_pred_shape[-1] == 1:`