### PR TITLE
Fix page rendering for SidecarEvaluatorModelExport

### DIFF
--- a/tf_keras/utils/sidecar_evaluator.py
+++ b/tf_keras/utils/sidecar_evaluator.py
@@ -381,6 +381,7 @@ class SidecarEvaluatorModelExport(ModelCheckpoint):
     )
     sidecar_evaluator.start()
     # Model weights are saved if evaluator deems it's the best seen so far.
+    ```
 
     Args:
         export_filepath: Path where best models should be saved by this


### PR DESCRIPTION
In the tensorflow.org the documentation page of tf.keras.callbacks.SidecarEvaluatorModelExport showing content of raw HTML pages. The reason may be that the Python code fence was not closed causing the page view breaking. Hence correcting the mistake.

Fixes TF ticket [61375](https://github.com/tensorflow/tensorflow/issues/61375).

Discussed in #657.