### PR TITLE
Updated the export_lib.py

### DIFF
--- a/tf_keras/export/export_lib.py
+++ b/tf_keras/export/export_lib.py
@@ -244,7 +244,7 @@ class ExportArchive(tf.__internal__.tracking.AutoTrackable):
             decorated_fn = tf.function(fn, input_signature=input_signature)
             self._endpoint_signatures[name] = input_signature
         else:
-            if isinstance(fn, tf.types.experimental.GenericFunction):
+            if isinstance(fn, tf.types.experimental.PolymorphicFunction):
                 if not fn._list_all_concrete_functions():
                     raise ValueError(
                         f"The provided tf.function '{fn}' "


### PR DESCRIPTION
In Tensorflow v2.15, `tf.types.experimental.GenericFunction` has been renamed to `tf.types.experimental.PolymorphicFunction`