### PR TITLE
Cherry pick r2.16

### DIFF
--- a/oss_setup.py
+++ b/oss_setup.py
@@ -63,7 +63,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Mathematics",

--- a/oss_setup.py
+++ b/oss_setup.py
@@ -39,7 +39,9 @@ with open(os.path.abspath(__file__)) as f:
 
 # pin version to that of tensorflow or tf_nightly.
 if "nightly" in "{{PACKAGE}}":
-    install_requires = ["tf-nightly~={{VERSION}}.dev"]
+    version = "{{VERSION}}"  # 2.17.0.dev2024021419
+    base_version = version.split(".dev")[0]
+    install_requires = [f"tf-nightly~={base_version}.dev"]
 else:
     install_requires = ["tensorflow~={{VERSION}}"]
 

--- a/oss_setup.py
+++ b/oss_setup.py
@@ -37,6 +37,12 @@ with open(os.path.abspath(__file__)) as f:
             "`pip_build.py` instead of `setup.py`."
         )
 
+# pin version to that of tensorflow or tf_nightly.
+if "nightly" in "{{PACKAGE}}":
+    install_requires = ["tf-nightly~={{VERSION}}.dev"]
+else:
+    install_requires = ["tensorflow~={{VERSION}}"]
+
 setuptools.setup(
     name="{{PACKAGE}}",
     # Version strings with `-` characters are semver compatible,
@@ -49,7 +55,7 @@ setuptools.setup(
     author="Keras team",
     author_email="keras-users@googlegroups.com",
     packages=setuptools.find_packages(),
-    install_requires=[],
+    install_requires=install_requires,
     # Supported Python versions
     python_requires=">=3.9",
     # PyPI package information.
@@ -63,6 +69,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Mathematics",

--- a/pip_build.py
+++ b/pip_build.py
@@ -449,13 +449,14 @@ def test_wheel(wheel_path, expected_version, requirements_path):
     checks = ";".join(symbols_to_check)
     # Uninstall `keras-nightly` after installing requirements
     # otherwise both will register `experimentalOptimizer` and test will fail.
+    # Skip install deps for `tf_keras` as TensorFlow installed from requirements
     script = (
         "#!/bin/bash\n"
         "virtualenv kenv\n"
         f"source {os.path.join('kenv', 'bin', 'activate')}\n"
         f"pip3 install -r {requirements_path}\n"
         "pip3 uninstall -y keras-nightly\n"
-        f"pip3 install {wheel_path} --force-reinstall\n"
+        f"pip3 install {wheel_path} --force-reinstall --no-deps\n"
         f"python3 -c 'import tf_keras;{checks};print(tf_keras.__version__)'\n"
     )
     try:

--- a/tf_keras/__init__.py
+++ b/tf_keras/__init__.py
@@ -20,6 +20,7 @@ Detailed documentation and user guides are available at
 
 from tf_keras import applications
 from tf_keras import distribute
+from tf_keras import layers
 from tf_keras import losses
 from tf_keras import metrics
 from tf_keras import models

--- a/tf_keras/tools/pip_package/setup.py
+++ b/tf_keras/tools/pip_package/setup.py
@@ -70,7 +70,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Mathematics",


### PR DESCRIPTION
* Cherry pick #749 to expose layer API in tf_keras.
* Cherry pick #748 Add `tensorflow` as dependency to `tf_keras` setup so that users will get the version that matches their TensorFlow installed version.

Cherrypick these two commits for 2.16 Release branch.