### PR TITLE
Cherry pick for allowing Minor version differences with TensorFlow

### DIFF
--- a/oss_setup.py
+++ b/oss_setup.py
@@ -39,14 +39,23 @@ with open(os.path.abspath(__file__)) as f:
 
 # pin version to that of tensorflow or tf_nightly.
 version = "{{VERSION}}".lower()
+major_version, minor_version, *_ = version.split(".")
+next_minor_version = int(minor_version) + 1
 if "nightly" in "{{PACKAGE}}":
     base_version = version.split(".dev")[0]  # 2.17.0.dev2024021419
     install_requires = [f"tf-nightly~={base_version}.dev"]
 elif "rc" in version:
-    base_version = version.split("rc")[0]  # 2.16.0rc0
-    install_requires = [f"tensorflow~={base_version}rc"]
+    # 2.17.0rc0
+    install_requires = [
+        f"tensorflow>={major_version}.{minor_version}.0rc0, "
+        f"<{major_version}.{next_minor_version}"
+    ]
 else:
-    install_requires = ["tensorflow~={{VERSION}}"]
+    # Match any TF patch version since patches shouldn't break compatibility.
+    install_requires = [
+        f"tensorflow>={major_version}.{minor_version}, "
+        f"<{major_version}.{next_minor_version}"
+    ]
 
 setuptools.setup(
     name="{{PACKAGE}}",


### PR DESCRIPTION
Update tf-keras version requirements to match TF version ignoring the minor version. This allows `tf-keras` and `TensorFlow` to have their own patch releases without having to have a corresponding patch release.

PiperOrigin-RevId: 612968532