### PR TITLE
Cherry pick r2.15 tf deps for r2.15 patch release

### DIFF
--- a/oss_setup.py
+++ b/oss_setup.py
@@ -39,7 +39,9 @@ with open(os.path.abspath(__file__)) as f:
 
 # pin version to that of tensorflow or tf_nightly.
 if "nightly" in "{{PACKAGE}}":
-    install_requires = ["tf-nightly~={{VERSION}}.dev"]
+    version = "{{VERSION}}"  # 2.17.0.dev2024021419
+    base_version = version.split(".dev")[0]
+    install_requires = [f"tf-nightly~={base_version}.dev"]
 else:
     install_requires = ["tensorflow~={{VERSION}}"]
 

--- a/oss_setup.py
+++ b/oss_setup.py
@@ -39,14 +39,23 @@ with open(os.path.abspath(__file__)) as f:
 
 # pin version to that of tensorflow or tf_nightly.
 version = "{{VERSION}}".lower()
+major_version, minor_version, *_ = version.split(".")
+next_minor_version = int(minor_version) + 1
 if "nightly" in "{{PACKAGE}}":
     base_version = version.split(".dev")[0]  # 2.17.0.dev2024021419
     install_requires = [f"tf-nightly~={base_version}.dev"]
 elif "rc" in version:
-    base_version = version.split("rc")[0]  # 2.16.0rc0
-    install_requires = [f"tensorflow~={base_version}rc"]
+    # 2.17.0rc0
+    install_requires = [
+        f"tensorflow>={major_version}.{minor_version}.0rc0, "
+        f"<{major_version}.{next_minor_version}"
+    ]
 else:
-    install_requires = ["tensorflow~={{VERSION}}"]
+    # Match any TF patch version since patches shouldn't break compatibility.
+    install_requires = [
+        f"tensorflow>={major_version}.{minor_version}, "
+        f"<{major_version}.{next_minor_version}"
+    ]
 
 setuptools.setup(
     name="{{PACKAGE}}",

--- a/oss_setup.py
+++ b/oss_setup.py
@@ -37,6 +37,12 @@ with open(os.path.abspath(__file__)) as f:
             "`pip_build.py` instead of `setup.py`."
         )
 
+# pin version to that of tensorflow or tf_nightly.
+if "nightly" in "{{PACKAGE}}":
+    install_requires = ["tf-nightly~={{VERSION}}.dev"]
+else:
+    install_requires = ["tensorflow~={{VERSION}}"]
+
 setuptools.setup(
     name="{{PACKAGE}}",
     # Version strings with `-` characters are semver compatible,
@@ -49,7 +55,7 @@ setuptools.setup(
     author="Keras team",
     author_email="keras-users@googlegroups.com",
     packages=setuptools.find_packages(),
-    install_requires=[],
+    install_requires=install_requires,
     # Supported Python versions
     python_requires=">=3.8",
     # PyPI package information.
@@ -64,6 +70,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Mathematics",

--- a/oss_setup.py
+++ b/oss_setup.py
@@ -38,10 +38,13 @@ with open(os.path.abspath(__file__)) as f:
         )
 
 # pin version to that of tensorflow or tf_nightly.
+version = "{{VERSION}}".lower()
 if "nightly" in "{{PACKAGE}}":
-    version = "{{VERSION}}"  # 2.17.0.dev2024021419
-    base_version = version.split(".dev")[0]
+    base_version = version.split(".dev")[0]  # 2.17.0.dev2024021419
     install_requires = [f"tf-nightly~={base_version}.dev"]
+elif "rc" in version:
+    base_version = version.split("rc")[0]  # 2.16.0rc0
+    install_requires = [f"tensorflow~={base_version}rc"]
 else:
     install_requires = ["tensorflow~={{VERSION}}"]
 

--- a/pip_build.py
+++ b/pip_build.py
@@ -450,6 +450,7 @@ def test_wheel(wheel_path, expected_version, requirements_path):
     # Use Env var `TENSORFLOW_VERSION` for specific TF version to use in release
     # Uninstall `keras` after installing requirements
     # otherwise both will register `experimentalOptimizer` and test will fail.
+    # Skip install deps for `tf_keras` as TensorFlow installed from requirements
     script = (
         "#!/bin/bash\n"
         "virtualenv kenv\n"
@@ -458,7 +459,7 @@ def test_wheel(wheel_path, expected_version, requirements_path):
         "pip3 uninstall -y tensorflow tf-nightly\n"
         'pip3 install "${TENSORFLOW_VERSION:-tf-nightly}"\n'
         "pip3 uninstall -y keras keras-nightly\n"
-        f"pip3 install {wheel_path} --force-reinstall\n"
+        f"pip3 install {wheel_path} --force-reinstall --no-deps\n"
         f"python3 -c 'import tf_keras;{checks};print(tf_keras.__version__)'\n"
     )
     try:


### PR DESCRIPTION
Add TensorFlow dependency for r2.15 to do a patch release so that users can't install `tf-keras 2.15` with `TensorFlow 2.16`. This will cause errors due to changes to Saved Model API.