### PR TITLE
fix vis_test pydot error

### DIFF
--- a/tf_keras/utils/vis_utils.py
+++ b/tf_keras/utils/vis_utils.py
@@ -56,7 +56,10 @@ def check_graphviz():
         # to check the pydot/graphviz installation.
         pydot.Dot.create(pydot.Dot())
         return True
-    except (OSError, pydot.InvocationException):
+    except (OSError, FileNotFoundError):
+        return False
+    # pydot_ng has InvocationException but pydot doesn't
+    except pydot.InvocationException:
         return False
 
 


### PR DESCRIPTION
pydot is failing `vis_utils_test.py` and is also same as what's reported in https://github.com/keras-team/keras/issues/19040

```
Traceback (most recent call last):
  File "/tmpfs/src/tf_keras_pip/tf-keras/venv_py/lib/python3.9/site-packages/tf_keras/src/utils/vis_utils.py", line 57, in check_graphviz
    pydot.Dot.create(pydot.Dot())
  File "/tmpfs/src/tf_keras_pip/tf-keras/venv_py/lib/python3.9/site-packages/pydot/core.py", line 1762, in create
    raise OSError(*args)
FileNotFoundError: [Errno 2] "dot" not found in path.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tmpfs/src/tf_keras_pip/tf-keras/venv_py/lib/python3.9/site-packages/absl/testing/parameterized.py", line 319, in bound_param_test
    return test_method(self, **testcase_params)
  File "/tmpfs/bazel_output/_bazel_kbuilder/2c1dc42bb13d516a7e3ea69411340d32/execroot/org_keras/bazel-out/k8-opt/bin/bazel_pip/tf_keras/utils/vis_utils_test.runfiles/org_keras/bazel_pip/tf_keras/utils/vis_utils_test.py", line 204, in test_layer_range_assertion_fail
    vis_utils.plot_model(model, layer_range=layer_range)
  File "/tmpfs/src/tf_keras_pip/tf-keras/venv_py/lib/python3.9/site-packages/tf_keras/src/utils/vis_utils.py", line 451, in plot_model
    if not check_graphviz():
  File "/tmpfs/src/tf_keras_pip/tf-keras/venv_py/lib/python3.9/site-packages/tf_keras/src/utils/vis_utils.py", line 59, in check_graphviz
    except (OSError, pydot.InvocationException):
AttributeError: module 'pydot' has no attribute 'InvocationException'

======================================================================
ERROR: test_layer_range_value_fail2 (layer_range=['input', 'block1a_activation', 'block1a_project_conv']) (__main__.ModelToDotFormatTest)
```