### PR TITLE
Fix the error handling for pydot installation check.

### DIFF
--- a/tf_keras/utils/vis_utils.py
+++ b/tf_keras/utils/vis_utils.py
@@ -56,7 +56,10 @@ def check_graphviz():
         # to check the pydot/graphviz installation.
         pydot.Dot.create(pydot.Dot())
         return True
-    except (OSError, pydot.InvocationException):
+    except (OSError, FileNotFoundError):
+        return False
+    # pydot_ng has InvocationException but pydot doesn't
+    except pydot.InvocationException:
         return False
 
 


### PR DESCRIPTION
`pydot.InvocationException` is only in `pydot_ng` and not in the `pydot` library.

PiperOrigin-RevId: 613787427