### PR TITLE
Prevent `load` statements from being combined by using `# buildifier:…

### DIFF
--- a/tf_keras/distribute/BUILD
+++ b/tf_keras/distribute/BUILD
@@ -3,9 +3,9 @@
 #   related to dist-strat used by TF-Keras..
 
 # Placeholder: load unaliased py_library
-load("@org_keras//tf_keras:tf_keras.bzl", "cuda_py_test")
+load("@org_keras//tf_keras:tf_keras.bzl", "cuda_py_test")  # buildifier: disable=same-origin-load
 load("@org_keras//tf_keras:tf_keras.bzl", "tf_py_test")  # buildifier: disable=same-origin-load
-load("@org_keras//tf_keras:tf_keras.bzl", "distribute_py_test")
+load("@org_keras//tf_keras:tf_keras.bzl", "distribute_py_test")  # buildifier: disable=same-origin-load
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tf_keras:license"],

--- a/tf_keras/engine/BUILD
+++ b/tf_keras/engine/BUILD
@@ -2,12 +2,8 @@
 #   Contains the TF-Keras engine API (internal TensorFlow version).
 
 # Placeholder: load unaliased py_library
-
-# buildifier: disable=same-origin-load
-load("@org_keras//tf_keras:tf_keras.bzl", "tf_py_test")
-
-# buildifier: disable=same-origin-load
-load("@org_keras//tf_keras:tf_keras.bzl", "cuda_py_test")
+load("@org_keras//tf_keras:tf_keras.bzl", "tf_py_test")  # buildifier: disable=same-origin-load
+load("@org_keras//tf_keras:tf_keras.bzl", "cuda_py_test")  # buildifier: disable=same-origin-load
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tf_keras:license"],

--- a/tf_keras/integration_test/BUILD
+++ b/tf_keras/integration_test/BUILD
@@ -2,10 +2,10 @@
 #   Contains TF-Keras integration tests that verify with other TF high level APIs.
 
 # Placeholder: load unaliased py_library
-load("@org_keras//tf_keras:tf_keras.bzl", "cuda_py_test")
+load("@org_keras//tf_keras:tf_keras.bzl", "cuda_py_test")  # buildifier: disable=same-origin-load
 load("@org_keras//tf_keras:tf_keras.bzl", "tf_py_test")  # buildifier: disable=same-origin-load
-load("@org_keras//tf_keras:tf_keras.bzl", "distribute_py_test")
-load("@org_keras//tf_keras:tf_keras.bzl", "tpu_py_test")
+load("@org_keras//tf_keras:tf_keras.bzl", "distribute_py_test")  # buildifier: disable=same-origin-load
+load("@org_keras//tf_keras:tf_keras.bzl", "tpu_py_test")  # buildifier: disable=same-origin-load
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tf_keras:license"],

--- a/tf_keras/layers/experimental/BUILD
+++ b/tf_keras/layers/experimental/BUILD
@@ -3,8 +3,8 @@
 # the training process.
 
 # Placeholder: load unaliased py_library
-load("@org_keras//tf_keras:tf_keras.bzl", "tf_py_test")
-load("@org_keras//tf_keras:tf_keras.bzl", "distribute_py_test")
+load("@org_keras//tf_keras:tf_keras.bzl", "tf_py_test")  # buildifier: disable=same-origin-load
+load("@org_keras//tf_keras:tf_keras.bzl", "distribute_py_test")  # buildifier: disable=same-origin-load
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//third_party/py/keras:license"],

--- a/tf_keras/layers/normalization/BUILD
+++ b/tf_keras/layers/normalization/BUILD
@@ -2,12 +2,8 @@
 #   Contains the TF-Keras normalization layers (internal TensorFlow version).
 
 # Placeholder: load unaliased py_library
-
-# buildifier: disable=same-origin-load
-load("@org_keras//tf_keras:tf_keras.bzl", "cuda_py_test")
-
-# buildifier: disable=same-origin-load
-load("@org_keras//tf_keras:tf_keras.bzl", "tf_py_test")
+load("@org_keras//tf_keras:tf_keras.bzl", "cuda_py_test")  # buildifier: disable=same-origin-load
+load("@org_keras//tf_keras:tf_keras.bzl", "tf_py_test")  # buildifier: disable=same-origin-load
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tf_keras:license"],

--- a/tf_keras/layers/preprocessing/BUILD
+++ b/tf_keras/layers/preprocessing/BUILD
@@ -2,11 +2,9 @@
 #   Contains the TF-Keras preprocess layers (internal TensorFlow version).
 
 # Placeholder: load unaliased py_library
-load("@org_keras//tf_keras:tf_keras.bzl", "tf_py_test")
-
-# buildifier: disable=same-origin-load
-load("@org_keras//tf_keras:tf_keras.bzl", "cuda_py_test")
-load("@org_keras//tf_keras:tf_keras.bzl", "distribute_py_test")
+load("@org_keras//tf_keras:tf_keras.bzl", "tf_py_test")  # buildifier: disable=same-origin-load
+load("@org_keras//tf_keras:tf_keras.bzl", "cuda_py_test")  # buildifier: disable=same-origin-load
+load("@org_keras//tf_keras:tf_keras.bzl", "distribute_py_test")  # buildifier: disable=same-origin-load
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tf_keras:license"],

--- a/tf_keras/layers/preprocessing/benchmarks/BUILD
+++ b/tf_keras/layers/preprocessing/benchmarks/BUILD
@@ -1,10 +1,8 @@
-# Placeholder: load unaliased py_library
-
 # Benchmarks for TF-Keras preprocessing layers.
-load("@org_keras//tf_keras:tf_keras.bzl", "cuda_py_test")
 
-# buildifier: disable=same-origin-load
-load("@org_keras//tf_keras:tf_keras.bzl", "tf_py_test")
+# Placeholder: load unaliased py_library
+load("@org_keras//tf_keras:tf_keras.bzl", "cuda_py_test")  # buildifier: disable=same-origin-load
+load("@org_keras//tf_keras:tf_keras.bzl", "tf_py_test")  # buildifier: disable=same-origin-load
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tf_keras:license"],

--- a/tf_keras/layers/rnn/BUILD
+++ b/tf_keras/layers/rnn/BUILD
@@ -2,10 +2,8 @@
 #  Contains the TF-Keras recurrent layers.
 
 # Placeholder: load unaliased py_library
-load("@org_keras//tf_keras:tf_keras.bzl", "cuda_py_test")
-
-# buildifier: disable=same-origin-load
-load("@org_keras//tf_keras:tf_keras.bzl", "tf_py_test")
+load("@org_keras//tf_keras:tf_keras.bzl", "cuda_py_test")  # buildifier: disable=same-origin-load
+load("@org_keras//tf_keras:tf_keras.bzl", "tf_py_test")  # buildifier: disable=same-origin-load
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tf_keras:license"],

--- a/tf_keras/legacy_tf_layers/BUILD
+++ b/tf_keras/legacy_tf_layers/BUILD
@@ -2,10 +2,8 @@
 #   Contains the legacy TF layers (internal TensorFlow version).
 
 # Placeholder: load unaliased py_library
-
-# buildifier: disable=same-origin-load
-load("@org_keras//tf_keras:tf_keras.bzl", "tf_py_test")
-load("@org_keras//tf_keras:tf_keras.bzl", "cuda_py_test")
+load("@org_keras//tf_keras:tf_keras.bzl", "tf_py_test")  # buildifier: disable=same-origin-load
+load("@org_keras//tf_keras:tf_keras.bzl", "cuda_py_test")  # buildifier: disable=same-origin-load
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tf_keras:license"],

--- a/tf_keras/mixed_precision/BUILD
+++ b/tf_keras/mixed_precision/BUILD
@@ -17,7 +17,7 @@
 #   Contains the TF-Keras Mixed Precision API (TensorFlow version).
 
 # Placeholder: load unaliased py_library
-load("@org_keras//tf_keras:tf_keras.bzl", "cuda_py_test")
+load("@org_keras//tf_keras:tf_keras.bzl", "cuda_py_test")  # buildifier: disable=same-origin-load
 load("@org_keras//tf_keras:tf_keras.bzl", "tf_py_test")  # buildifier: disable=same-origin-load
 
 package(

--- a/tf_keras/models/BUILD
+++ b/tf_keras/models/BUILD
@@ -1,8 +1,8 @@
 # TF-Keras models
 
 # Placeholder: load unaliased py_library
-load("@org_keras//tf_keras:tf_keras.bzl", "distribute_py_test")
-load("@org_keras//tf_keras:tf_keras.bzl", "tf_py_test")
+load("@org_keras//tf_keras:tf_keras.bzl", "tf_py_test")  # buildifier: disable=same-origin-load
+load("@org_keras//tf_keras:tf_keras.bzl", "distribute_py_test")  # buildifier: disable=same-origin-load
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tf_keras:license"],

--- a/tf_keras/optimizers/BUILD
+++ b/tf_keras/optimizers/BUILD
@@ -2,11 +2,9 @@
 #   Contains the TF-Keras Optimizer API.
 
 # Placeholder: load unaliased py_library
-load("@org_keras//tf_keras:tf_keras.bzl", "cuda_py_test")
-
-# buildifier: disable=same-origin-load
-load("@org_keras//tf_keras:tf_keras.bzl", "tf_py_test")
-load("@org_keras//tf_keras:tf_keras.bzl", "distribute_py_test")
+load("@org_keras//tf_keras:tf_keras.bzl", "cuda_py_test")  # buildifier: disable=same-origin-load
+load("@org_keras//tf_keras:tf_keras.bzl", "tf_py_test")  # buildifier: disable=same-origin-load
+load("@org_keras//tf_keras:tf_keras.bzl", "distribute_py_test")  # buildifier: disable=same-origin-load
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tf_keras:license"],

--- a/tf_keras/tests/BUILD
+++ b/tf_keras/tests/BUILD
@@ -3,13 +3,9 @@
 
 # Placeholder: load unaliased py_library
 # Placeholder: load unaliased py_test
-
-# buildifier: disable=same-origin-load
-load("@org_keras//tf_keras:tf_keras.bzl", "cuda_py_test")
-
-# buildifier: disable=same-origin-load
-load("@org_keras//tf_keras:tf_keras.bzl", "tf_py_test")
-load("@org_keras//tf_keras:tf_keras.bzl", "tpu_py_test")
+load("@org_keras//tf_keras:tf_keras.bzl", "cuda_py_test")  # buildifier: disable=same-origin-load
+load("@org_keras//tf_keras:tf_keras.bzl", "tf_py_test")  # buildifier: disable=same-origin-load
+load("@org_keras//tf_keras:tf_keras.bzl", "tpu_py_test")  # buildifier: disable=same-origin-load
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tf_keras:license"],


### PR DESCRIPTION
… disable=same-origin-load`