### PR TITLE
fixup 6f449910f2 - remaining random.randint calls

### DIFF
--- a/tf_keras/preprocessing/sequence.py
+++ b/tf_keras/preprocessing/sequence.py
@@ -375,7 +375,7 @@ def skipgrams(
 
     if shuffle:
         if seed is None:
-            seed = random.randint(0, 10e6)
+            seed = random.randint(0, int(10e6))
         random.seed(seed)
         random.shuffle(couples)
         random.seed(seed)

--- a/tf_keras/utils/text_dataset_test.py
+++ b/tf_keras/utils/text_dataset_test.py
@@ -33,7 +33,7 @@ class TextDatasetFromDirectoryTest(test_combinations.TestCase):
     ):
         # Get a unique temp directory
         temp_dir = os.path.join(
-            self.get_temp_dir(), str(random.randint(0, 1e6))
+            self.get_temp_dir(), str(random.randint(0, int(1e6)))
         )
         os.mkdir(temp_dir)
         self.addCleanup(shutil.rmtree, temp_dir)


### PR DESCRIPTION
- replace deprecated float arguments with int to fix Python 3.12 compatibility