### PR TITLE
Explictly use Py310 in github workflows

### DIFF
--- a/.github/workflows/auto-assignment.yaml
+++ b/.github/workflows/auto-assignment.yaml
@@ -16,7 +16,7 @@ jobs:
   welcome:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/github-script@v6
         with:
           script: |

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,15 +12,18 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
       - name: Get pip cache dir
         id: pip-cache
         run: |
           python -m pip install --upgrade pip setuptools
           echo "::set-output name=dir::$(pip cache dir)"
       - name: pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,15 +13,18 @@ jobs:
     name: Check the code format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
       - name: Get pip cache dir
         id: pip-cache
         run: |
           python -m pip install --upgrade pip setuptools
           echo "::set-output name=dir::$(pip cache dir)"
       - name: pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}


### PR DESCRIPTION
Code Linter Action is failing in the head. The issue is, it uses the latest Python 3.12 that doesn't work with the Flake version we are using. So downgrading to use Python 3.10. This is consistent to how we use in KerasTuner.

I will also update the main Keras Repo.