### PR TITLE
Fix memory leak by purging orphaned CustomGradients in clear_session

### DIFF
--- a/tf_keras/backend.py
+++ b/tf_keras/backend.py
@@ -306,7 +306,7 @@ def clear_session():
             gradient_dict = ops._gradient_registry._registry
             
             orphaned_gradients = [
-                name for name in gradient_dict.keys() 
+                name for name in list(gradient_dict.keys())
                 if isinstance(name, str) and name.startswith("CustomGradient")
             ]
             

--- a/tf_keras/backend.py
+++ b/tf_keras/backend.py
@@ -296,6 +296,28 @@ def clear_session():
         # step_containers.
         context.context().clear_kernel_cache()
 
+    # Clear dynamically generated custom gradients from the global registry.
+    # This severs the circular reference between the registry and Keras FuncGraphs,
+    # allowing Python's garbage collector to safely reclaim memory.
+    try:
+        from tensorflow.python.framework import ops
+        
+        if hasattr(ops, '_gradient_registry') and hasattr(ops._gradient_registry, '_registry'):
+            gradient_dict = ops._gradient_registry._registry
+            
+            orphaned_gradients = [
+                name for name in gradient_dict.keys() 
+                if isinstance(name, str) and name.startswith("CustomGradient")
+            ]
+            
+            for name in orphaned_gradients:
+                try:
+                    del gradient_dict[name]
+                except KeyError:
+                    pass
+    except Exception:
+        pass
+
 
 # Inject the clear_session function to keras_deps to remove the dependency
 # from TFLite to TF-Keras.


### PR DESCRIPTION
This PR fixes the memory leak that happens when training Keras models in a loop (e.g., repeatedly calling `model.fit()`). 

After doing some digging into the memory graph, I tracked down exactly why `clear_session()` wasn't freeing up the memory. The issue stems from how AutoGraph handles custom gradients (like `CustomGradient-42358`). It registers these closures permanently in the global `tensorflow.python.framework.ops._gradient_registry`. The problem is that these closures capture `SymbolicTensor` objects, which hold the Keras `FuncGraph` and its PyBind11 C++ wrappers. 

Because Python's garbage collector can't traverse PyBind11 objects, that single global registry entry ends up pinning the entire dead execution graph in memory forever, even after Keras destroys the actual `Model`.

**The Fix:**
This PR just updates `clear_session()` to explicitly drop these orphaned custom gradients from the global registry. Once that anchor is severed, the Python GC immediately tears down the `FuncGraph` and frees the C++ memory. 

*(Note for reviewers: I opted to purge all dynamically generated `CustomGradient` entries since `clear_session()` acts as a global reset. If you'd prefer to filter these more strictly by inspecting the closure graphs, just let me know and I'm happy to update it!)*

### Related Issues
Fixes tensorflow/tensorflow#80895
Fixes keras-team/tf-keras#286