### PR TITLE
Fix GlobalAveragePooling1D with an empty batch and a mask

### DIFF
--- a/tf_keras/layers/pooling/global_average_pooling1d.py
+++ b/tf_keras/layers/pooling/global_average_pooling1d.py
@@ -83,7 +83,7 @@ class GlobalAveragePooling1D(GlobalPooling1D):
     def call(self, inputs, mask=None):
         steps_axis = 1 if self.data_format == "channels_last" else 2
         if mask is not None:
-            mask = tf.cast(mask, inputs[0].dtype)
+            mask = tf.cast(mask, inputs.dtype)
             mask = tf.expand_dims(
                 mask, 2 if self.data_format == "channels_last" else 1
             )

--- a/tf_keras/layers/pooling/global_average_pooling_test.py
+++ b/tf_keras/layers/pooling/global_average_pooling_test.py
@@ -55,6 +55,13 @@ class GlobalAveragePoolingTest(tf.test.TestCase, parameterized.TestCase):
         output = model.predict(model_input)
         self.assertAllClose(output[0], model_input[0, 0, :])
 
+    def test_global_average_pooling_1d_with_empty_batch_and_mask(self):
+        inputs = np.random.random((0, 3, 4)).astype("float32")
+        mask = np.ones((0, 3), dtype="bool")
+        layer = keras.layers.GlobalAveragePooling1D()
+        output = layer(inputs, mask)
+        self.assertAllEqual(output.shape, (0, 4))
+
     def test_global_average_pooling_1d_with_ragged(self):
         ragged_data = tf.ragged.constant(
             [[[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]], [[1.0, 1.0], [2.0, 2.0]]],


### PR DESCRIPTION
Fixes the crash when GlobalAveragePooling1D is called on an empty batch with a mask (StridedSlice index 0 of dimension 0 out of bounds), e.g. under MirroredStrategy when a replica gets an empty shard.

The cast `tf.cast(mask, inputs[0].dtype)` indexes the batch dim; changing it to `inputs.dtype` avoids touching the data. Includes a regression test in global_average_pooling_test.py (passes in graph and eager modes).

Upstream issue: https://github.com/tensorflow/tensorflow/issues/67023