### PR TITLE
Run `lint` on `push` only for `master`.

### DIFF
--- a/.github/workflows/auto-assignment.yaml
+++ b/.github/workflows/auto-assignment.yaml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  welcome:
+  assign:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,7 @@ name: Lint
 
 on:
   push:
+    branches: [ master ]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Currently, PRs run the same workflow twice because they trigger both `push` and `pull_request`.