### PR TITLE
Honor safe_mode on the legacy/.h5 path and restrict Lambda function-gadget module resolution

### DIFF
--- a/tf_keras/saving/saving_api.py
+++ b/tf_keras/saving/saving_api.py
@@ -298,12 +298,20 @@ def load_model(
             )
 
         # Legacy case.
-        return legacy_sm_saving_lib.load_model(
-            local_filepath,
-            custom_objects=custom_objects,
-            compile=compile,
-            **kwargs,
-        )
+        # Establish the safe-mode scope so that `safe_mode` is honored on the
+        # legacy (`.h5`/SavedModel) path too. Without this, the legacy loader
+        # never enters a `SafeModeScope`, `in_safe_mode()` defaults to falsy,
+        # and unsafe `Lambda` deserialization runs even when `safe_mode=True`.
+        # Imported lazily to avoid a circular import at module load time.
+        from tf_keras.saving.serialization_lib import SafeModeScope
+
+        with SafeModeScope(safe_mode):
+            return legacy_sm_saving_lib.load_model(
+                local_filepath,
+                custom_objects=custom_objects,
+                compile=compile,
+                **kwargs,
+            )
 
 
 def save_weights(model, filepath, overwrite=True, **kwargs):

--- a/tf_keras/saving/serialization_lib.py
+++ b/tf_keras/saving/serialization_lib.py
@@ -789,6 +789,26 @@ def _retrieve_class_or_fn(
                 if obj is not None:
                     return obj
 
+        # Under safe mode, restrict module resolution to TF-Keras / TensorFlow
+        # modules. Importing an arbitrary module here (e.g. `os`, `subprocess`,
+        # `builtins`) and fetching a symbol from it is an arbitrary-code-execution
+        # vector, because a `Lambda` layer's `function` can name any
+        # module/callable. Legitimate built-in symbols are already resolved
+        # above; only the arbitrary-import fall-through is blocked.
+        if in_safe_mode():
+            safe_root = module.split(".", 1)[0]
+            if safe_root not in ("keras", "tf_keras", "tensorflow", "numpy"):
+                raise ValueError(
+                    f"Requested the deserialization of a `{obj_type}` from "
+                    f"module `{module}`, which is not an allowed TF-Keras / "
+                    "TensorFlow module. This carries a potential risk of "
+                    "arbitrary code execution and thus it is disallowed when "
+                    "`safe_mode=True` (the default). If you trust the source of "
+                    "the saved model, you can pass `safe_mode=False` to the "
+                    "loading function. "
+                    f"Full object config: {full_config}"
+                )
+
         # Otherwise, attempt to retrieve the class object given the `module`
         # and `class_name`. Import the module, find the class.
         try:

--- a/tf_keras/saving/serialization_lib_test.py
+++ b/tf_keras/saving/serialization_lib_test.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """Tests for serialization_lib."""
 
+import os
 import json
 
 import numpy as np
@@ -197,6 +198,25 @@ class SerializationLibTest(tf.test.TestCase, parameterized.TestCase):
         y1 = lmbda(x)
         y2 = new_lmbda(x)
         self.assertAllClose(y1, y2, atol=1e-5)
+
+    def test_function_gadget_blocked_in_safe_mode(self):
+        # A `Lambda` layer's `function` config can name any module/callable;
+        # resolving one from a non-Keras module (e.g. `os.system`) under
+        # safe_mode is an arbitrary-code-execution vector and must be blocked.
+        gadget = {
+            "class_name": "function",
+            "config": "system",
+            "module": "os",
+            "registered_name": "system",
+        }
+        with serialization_lib.SafeModeScope(safe_mode=True):
+            with self.assertRaisesRegex(ValueError, "arbitrary code execution"):
+                serialization_lib.deserialize_keras_object(gadget)
+        # With safe_mode disabled, resolution proceeds (documented escape hatch).
+        with serialization_lib.SafeModeScope(safe_mode=False):
+            self.assertIs(
+                serialization_lib.deserialize_keras_object(gadget), os.system
+            )
 
     def test_tensorspec(self):
         inputs = keras.Input(type_spec=tf.TensorSpec((2, 2), tf.float32))


### PR DESCRIPTION
## Summary

`load_model(..., safe_mode=True)` (the default) is documented to "disallow unsafe `lambda` deserialization", but two paths do not honor it. This brings tf-keras in line with the `safe_mode` hardening that landed in Keras 3 (which had the same gaps).

### 1. Arbitrary module/gadget resolution under `safe_mode`
For a `Lambda` layer whose `function` config is `function_type=="function"`, `_retrieve_class_or_fn` (`serialization_lib.py`) imports the module named in the config and fetches a symbol from it **with no restriction** — so a config naming `os` / `subprocess` / `builtins` resolves an arbitrary callable (e.g. `os.system`) and installs it as the layer's `function`, **even under `safe_mode=True`**. Only the `function_type=="lambda"` path was guarded.

Fix: under safe mode, restrict the module-import fall-through to TF-Keras / TensorFlow modules (`keras`, `tf_keras`, `tensorflow`, `numpy`); legitimate built-in symbols are still resolved by the existing fast paths above. Anything else raises with the standard `safe_mode` message and the `safe_mode=False` escape hatch.

### 2. Legacy (`.h5` / SavedModel) load silently ignores `safe_mode`
`load_model(path, safe_mode=True)` dispatches `.h5`/`.hdf5` to the legacy loader **without passing or scoping `safe_mode`** (`saving_api.py`). The legacy path therefore never enters a `SafeModeScope`, `in_safe_mode()` defaults to falsy, and unsafe `Lambda` bytecode loads even when `safe_mode=True`.

Fix: wrap the legacy load in `SafeModeScope(safe_mode)` so the existing unsafe-lambda guard fires on the `.h5` path too (matching the `.keras` path's behavior).

## Tests
Added `test_function_gadget_blocked_in_safe_mode` (gadget from a non-Keras module is rejected under safe mode, allowed under `safe_mode=False`). Verified locally on `tf-keras==2.21.0`: with these changes, loading a crafted `.h5` Lambda model and resolving an `os.system` gadget both raise under the default `safe_mode=True` (previously both succeeded).

## Compatibility
`safe_mode=False` continues to allow all of the above (the documented opt-out). Legitimate Keras/TensorFlow Lambda functions resolve unchanged.
