### PR TITLE
fix(saving): propagate safe_mode to the legacy HDF5 load path

### DIFF
--- a/tf_keras/saving/saving_api.py
+++ b/tf_keras/saving/saving_api.py
@@ -23,6 +23,7 @@ import tensorflow.compat.v2 as tf
 from tensorflow.python.util.tf_export import keras_export
 
 from tf_keras.saving import saving_lib
+from tf_keras.saving import serialization_lib
 from tf_keras.saving.legacy import save as legacy_sm_saving_lib
 from tf_keras.saving.legacy import saving_utils
 from tf_keras.utils import io_utils
@@ -298,12 +299,18 @@ def load_model(
             )
 
         # Legacy case.
-        return legacy_sm_saving_lib.load_model(
-            local_filepath,
-            custom_objects=custom_objects,
-            compile=compile,
-            **kwargs,
-        )
+        # `safe_mode` isn't threaded through the legacy loader's own
+        # signature, so propagate it via SafeModeScope, the same
+        # mechanism the .keras (v3) path above relies on. Without this,
+        # Lambda-layer deserialization inside the legacy path never sees
+        # the caller's safe_mode value.
+        with serialization_lib.SafeModeScope(safe_mode):
+            return legacy_sm_saving_lib.load_model(
+                local_filepath,
+                custom_objects=custom_objects,
+                compile=compile,
+                **kwargs,
+            )
 
 
 def save_weights(model, filepath, overwrite=True, **kwargs):

--- a/tf_keras/saving/saving_api.py
+++ b/tf_keras/saving/saving_api.py
@@ -304,7 +304,16 @@ def load_model(
         # mechanism the .keras (v3) path above relies on. Without this,
         # Lambda-layer deserialization inside the legacy path never sees
         # the caller's safe_mode value.
-        with serialization_lib.SafeModeScope(safe_mode):
+        #
+        # Resolve against an outer scope first, matching how
+        # deserialize_keras_object resolves it on the v3 path, so an
+        # active outer SafeModeScope (e.g. from enable_unsafe_deserialization())
+        # isn't silently overridden by this function's own safe_mode default.
+        safe_scope_arg = serialization_lib.in_safe_mode()
+        resolved_safe_mode = (
+            safe_scope_arg if safe_scope_arg is not None else safe_mode
+        )
+        with serialization_lib.SafeModeScope(resolved_safe_mode):
             return legacy_sm_saving_lib.load_model(
                 local_filepath,
                 custom_objects=custom_objects,


### PR DESCRIPTION
Summary

load_model()'s legacy-format branch in saving_api.py calls legacy_sm_saving_lib.load_model() without passing safe_mode through. The thread-local flag that Lambda._parse_function_from_config checks (in_safe_mode(), set via SafeModeScope) is only ever entered on the .keras (v3) code path. On the legacy .h5 path it is never set, so safe_mode=True (the default) has no effect there.

File changed: tf_keras/saving/saving_api.py

Fix - propagate safe_mode to the legacy load path

BEFORE:

# Legacy case.
return legacy_sm_saving_lib.load_model(
    local_filepath,
    custom_objects=custom_objects,
    compile=compile,
    **kwargs,
)

AFTER:

# Legacy case.
with serialization_lib.SafeModeScope(safe_mode):
    return legacy_sm_saving_lib.load_model(
        local_filepath,
        custom_objects=custom_objects,
        compile=compile,
        **kwargs,
    )

This wraps the legacy call in the same SafeModeScope context manager the .keras (v3) path above already uses, so in_safe_mode() reflects the caller's safe_mode argument regardless of which format is being loaded.

Testing

Verified with a standalone repro: a .h5 model containing a Lambda layer. Before the fix, load_model(path) with the default safe_mode=True loaded the model without raising and the Lambda ran on predict(). After the fix, the same call raises the same ValueError the .keras path already raises for the same case ("Requested the deserialization of a Lambda layer... disallowed by default"). Confirmed no regression: a normal .h5 model with no Lambda layer loads and predicts correctly both with the default safe_mode and with safe_mode explicitly set to True or False.

Related

The same gap (safe_mode not enforced on the .h5 loader) was fixed in the separate keras-team/keras package as GHSA-36rr-ww3j-vrjv, in 3.11.3. tf-keras is an independent codebase (own saving_api.py, serialization_lib.py, legacy loader) and did not receive that fix.