### PR TITLE
Reject HDF5 datasets that read the host or blow up memory

### DIFF
--- a/tf_keras/saving/BUILD
+++ b/tf_keras/saving/BUILD
@@ -28,6 +28,7 @@ py_library(
     ],
     # copybara:uncomment strict_deps = False,
     deps = [
+        ":h5_utils",
         ":object_registration",
         ":serialization",
         ":serialization_lib",
@@ -57,10 +58,23 @@ py_library(
     ],
     # copybara:uncomment strict_deps = False,
     deps = [
+        ":h5_utils",
         ":serialization_lib",
         "//:tf_nightly_with_deps",  # "//third_party/py/tensorflow:tensorflow_core"
         "//tf_keras/utils:generic_utils",
         "//tf_keras/utils:io_utils",
+    ],
+)
+
+tf_py_test(
+    name = "h5_utils_test",
+    size = "small",
+    srcs = ["h5_utils_test.py"],
+    deps = [
+        ":h5_utils",
+        "//:tf_nightly_with_deps",  # "//third_party/py/tensorflow:tensorflow_core"
+        "@pypi//h5py",
+        "@pypi//numpy",
     ],
 )
 
@@ -75,6 +89,17 @@ tf_py_test(
         "//tf_keras/testing_infra:test_combinations",
         "//tf_keras/utils:generic_utils",
         "@pypi//absl_py",  # absl/testing:parameterized
+    ],
+)
+
+py_library(
+    name = "h5_utils",
+    srcs = [
+        "h5_utils.py",
+    ],
+    # copybara:uncomment strict_deps = False,
+    deps = [
+        "@pypi//h5py",
     ],
 )
 

--- a/tf_keras/saving/h5_utils.py
+++ b/tf_keras/saving/h5_utils.py
@@ -1,0 +1,143 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Guarded accessors for datasets and groups inside an HDF5 file.
+
+A saved model is untrusted data, so reading one must not let the file drive
+reads of the host filesystem or force an unbounded allocation. HDF5 offers
+several ways to do exactly that, none of which a model file has any reason to
+use: external storage (a dataset whose raw bytes live in a separate file),
+external and soft links (an object that resolves elsewhere), virtual datasets
+(a dataset mapped from other files), and datasets whose declared shape is far
+larger than the bytes actually stored.
+
+These helpers mirror `safe_get_h5_dataset` / `safe_get_h5_group` in Keras 3
+(`keras/src/saving/saving_lib.py`), which is where the same guards landed for
+CVE-2026-1669.
+"""
+
+import math
+
+try:
+    import h5py
+except ImportError:
+    h5py = None
+
+
+# Guard against HDF5 "shape bomb" datasets: a dataset can declare an enormous
+# shape while storing almost nothing on disk (e.g. chunked + gzip-compressed
+# with only a fill value), which forces a huge allocation when it is read into
+# memory (CWE-789 / CWE-409). For datasets whose declared in-memory size is
+# above this floor, we require it to stay within `_H5_DATASET_MAX_EXPANSION` of
+# the bytes actually stored on disk. Weights written by TF-Keras are dense and
+# uncompressed, so they satisfy this; shape/decompression bombs, which store
+# next to nothing, do not.
+_H5_DATASET_BOMB_FLOOR_BYTES = 1 << 32  # 4 GiB
+_H5_DATASET_MAX_EXPANSION = 1000
+
+
+def safe_get_h5_group(parent, name):
+    """Retrieves a Group within a given Group, rejecting unsafe links.
+
+    Args:
+        parent: the parent `h5py.Group`.
+        name: the name of the Group to retrieve. May be a `/`-separated path.
+
+    Returns:
+        The child `h5py.Group`.
+
+    Raises:
+        ValueError: if any path component resolves through an external or soft
+            link, or is not a Group.
+        KeyError: if the path does not exist.
+    """
+    current = parent
+    for name_part in name.split("/"):
+        if not name_part:
+            raise ValueError(f"Invalid path in H5 file: {name}")
+
+        # Also handles the case when the group is an empty dict initially.
+        if name_part not in current:
+            raise KeyError(name)
+
+        if isinstance(current, dict):
+            group_type = None
+        else:
+            group_type = current.get(
+                name_part, default=None, getclass=True, getlink=True
+            )
+
+        if group_type in (h5py.ExternalLink, h5py.SoftLink):
+            raise ValueError(f"Not allowed: H5 file with {group_type.__name__}")
+
+        current = current[name_part]
+        if not isinstance(current, h5py.Group):
+            raise ValueError(
+                f"Invalid H5 file, expected Group but received {type(current)}"
+            )
+
+    return current
+
+
+def safe_get_h5_dataset(group, name):
+    """Retrieves a Dataset within a given Group, rejecting unsafe datasets.
+
+    Args:
+        group: the parent `h5py.Group`.
+        name: the name of the Dataset to retrieve. May be a `/`-separated path.
+
+    Returns:
+        The child `h5py.Dataset`.
+
+    Raises:
+        ValueError: if the dataset resolves through an external or soft link,
+            uses external or virtual storage, or declares a shape far larger
+            than the bytes stored on disk.
+        KeyError: if the path does not exist.
+    """
+    if "/" in name:
+        # Separate the dataset name from its parent group.
+        group_name, name = name.rsplit("/", 1)
+        group = safe_get_h5_group(group, group_name)
+
+    # Also handles the case when the group is an empty dict initially.
+    if name not in group:
+        raise KeyError(name)
+
+    dataset_type = group.get(name, default=None, getclass=True, getlink=True)
+    if dataset_type in (h5py.ExternalLink, h5py.SoftLink):
+        raise ValueError(f"Not allowed: H5 file with {dataset_type.__name__}")
+
+    dataset = group[name]
+    if not isinstance(dataset, h5py.Dataset):
+        raise ValueError(
+            f"Invalid H5 file, expected Dataset, received {type(dataset)}"
+        )
+    if dataset.external:
+        raise ValueError(
+            f"Not allowed: H5 file with external Dataset: {dataset.external}"
+        )
+    if dataset.is_virtual:
+        raise ValueError("Not allowed: H5 file with virtual Dataset")
+    declared_bytes = math.prod(dataset.shape) * dataset.dtype.itemsize
+    stored_bytes = dataset.id.get_storage_size()
+    if (
+        declared_bytes > _H5_DATASET_BOMB_FLOOR_BYTES
+        and declared_bytes > _H5_DATASET_MAX_EXPANSION * stored_bytes
+    ):
+        raise ValueError(
+            "Not allowed: H5 file with a Dataset declaring "
+            f"{declared_bytes} bytes but storing only {stored_bytes} bytes"
+        )
+    return dataset

--- a/tf_keras/saving/h5_utils_test.py
+++ b/tf_keras/saving/h5_utils_test.py
@@ -1,0 +1,151 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for the guarded HDF5 accessors."""
+
+import os
+
+import numpy as np
+import tensorflow.compat.v2 as tf
+
+from tf_keras.saving import h5_utils
+
+try:
+    import h5py
+except ImportError:
+    h5py = None
+
+
+class SafeH5AccessTest(tf.test.TestCase):
+    def _path(self, name):
+        return os.path.join(self.get_temp_dir(), name)
+
+    def test_reads_a_regular_dataset(self):
+        path = self._path("plain.h5")
+        with h5py.File(path, "w") as f:
+            f.create_group("g").create_dataset("d", data=np.arange(4))
+
+        with h5py.File(path, "r") as f:
+            self.assertAllEqual(
+                np.asarray(h5_utils.safe_get_h5_dataset(f["g"], "d")),
+                np.arange(4),
+            )
+            # A `/`-separated path resolves through the parent group.
+            self.assertAllEqual(
+                np.asarray(h5_utils.safe_get_h5_dataset(f, "g/d")),
+                np.arange(4),
+            )
+            self.assertIsInstance(
+                h5_utils.safe_get_h5_group(f, "g"), h5py.Group
+            )
+
+    def test_rejects_external_storage_dataset(self):
+        # An external dataset stores its bytes in another file on the host, so
+        # reading it would disclose that file's contents.
+        secret = self._path("secret.bin")
+        with open(secret, "wb") as f:
+            f.write(b"S" * 32)
+        path = self._path("external.h5")
+        with h5py.File(path, "w") as f:
+            f.create_dataset(
+                "d",
+                shape=(4,),
+                dtype="float64",
+                external=[(secret, 0, h5py.h5f.UNLIMITED)],
+            )
+
+        with h5py.File(path, "r") as f:
+            with self.assertRaisesRegex(ValueError, "external Dataset"):
+                h5_utils.safe_get_h5_dataset(f, "d")
+
+    def test_rejects_external_and_soft_links(self):
+        other = self._path("other.h5")
+        with h5py.File(other, "w") as f:
+            f.create_dataset("d", data=np.arange(4))
+            f.create_group("g")
+        path = self._path("linked.h5")
+        with h5py.File(path, "w") as f:
+            f["ext_dataset"] = h5py.ExternalLink(other, "d")
+            f["ext_group"] = h5py.ExternalLink(other, "g")
+            f.create_dataset("real", data=np.arange(4))
+            f["soft_dataset"] = h5py.SoftLink("/real")
+
+        with h5py.File(path, "r") as f:
+            with self.assertRaisesRegex(ValueError, "ExternalLink"):
+                h5_utils.safe_get_h5_dataset(f, "ext_dataset")
+            with self.assertRaisesRegex(ValueError, "SoftLink"):
+                h5_utils.safe_get_h5_dataset(f, "soft_dataset")
+            with self.assertRaisesRegex(ValueError, "ExternalLink"):
+                h5_utils.safe_get_h5_group(f, "ext_group")
+
+    def test_rejects_virtual_dataset(self):
+        source = self._path("source.h5")
+        with h5py.File(source, "w") as f:
+            f.create_dataset("d", data=np.arange(4, dtype="float64"))
+        path = self._path("virtual.h5")
+        layout = h5py.VirtualLayout(shape=(4,), dtype="float64")
+        layout[:] = h5py.VirtualSource(source, "d", shape=(4,))
+        with h5py.File(path, "w") as f:
+            f.create_virtual_dataset("d", layout)
+
+        with h5py.File(path, "r") as f:
+            with self.assertRaisesRegex(ValueError, "virtual Dataset"):
+                h5_utils.safe_get_h5_dataset(f, "d")
+
+    def test_rejects_shape_bomb(self):
+        # A tiny file can declare a dataset far larger than it stores, which
+        # would force an enormous allocation when read.
+        path = self._path("bomb.h5")
+        with h5py.File(path, "w") as f:
+            f.create_dataset(
+                "d", shape=(10**11,), dtype="float64", compression="gzip"
+            )
+
+        with h5py.File(path, "r") as f:
+            with self.assertRaisesRegex(ValueError, "storing only"):
+                h5_utils.safe_get_h5_dataset(f, "d")
+
+    def test_accepts_dataset_below_the_bomb_floor(self):
+        # The bomb guard has a 4 GiB floor, so ordinary weights are unaffected
+        # no matter how well they compress.
+        path = self._path("large.h5")
+        with h5py.File(path, "w") as f:
+            f.create_dataset(
+                "d", data=np.zeros(1024, dtype="float64"), compression="gzip"
+            )
+
+        with h5py.File(path, "r") as f:
+            self.assertEqual(
+                h5_utils.safe_get_h5_dataset(f, "d").shape, (1024,)
+            )
+
+    def test_raises_for_missing_and_wrong_type(self):
+        path = self._path("shapes.h5")
+        with h5py.File(path, "w") as f:
+            f.create_group("g").create_dataset("d", data=np.arange(4))
+
+        with h5py.File(path, "r") as f:
+            with self.assertRaises(KeyError):
+                h5_utils.safe_get_h5_dataset(f, "nope")
+            with self.assertRaises(KeyError):
+                h5_utils.safe_get_h5_group(f, "nope")
+            with self.assertRaisesRegex(ValueError, "expected Dataset"):
+                h5_utils.safe_get_h5_dataset(f, "g")
+            with self.assertRaisesRegex(ValueError, "expected Group"):
+                h5_utils.safe_get_h5_group(f, "g/d")
+
+
+if __name__ == "__main__":
+    if h5py is not None:
+        tf.test.main()

--- a/tf_keras/saving/legacy/hdf5_format.py
+++ b/tf_keras/saving/legacy/hdf5_format.py
@@ -24,6 +24,7 @@ import tensorflow.compat.v2 as tf
 from tf_keras import backend
 from tf_keras.optimizers import optimizer as optimizer_base
 from tf_keras.optimizers import optimizer_v1
+from tf_keras.saving import h5_utils
 from tf_keras.saving import object_registration
 from tf_keras.saving.legacy import model_config as model_config_lib
 from tf_keras.saving.legacy import saving_utils
@@ -205,7 +206,9 @@ def load_model_from_hdf5(filepath, custom_objects=None, compile=True):
         )
 
         # set weights
-        load_weights_from_hdf5_group(f["model_weights"], model)
+        load_weights_from_hdf5_group(
+            h5_utils.safe_get_h5_group(f, "model_weights"), model
+        )
 
         if compile:
             # instantiate optimizer
@@ -706,12 +709,13 @@ def load_optimizer_weights_from_hdf5_group(hdf5_group):
     Returns:
         data: List of optimizer weight names.
     """
-    weights_group = hdf5_group["optimizer_weights"]
+    weights_group = h5_utils.safe_get_h5_group(hdf5_group, "optimizer_weights")
     optimizer_weight_names = load_attributes_from_hdf5_group(
         weights_group, "weight_names"
     )
     return [
-        weights_group[weight_name] for weight_name in optimizer_weight_names
+        h5_utils.safe_get_h5_dataset(weights_group, weight_name)
+        for weight_name in optimizer_weight_names
     ]
 
 
@@ -774,7 +778,10 @@ def load_subset_weights_from_hdf5_group(f):
             and weights file.
     """
     weight_names = load_attributes_from_hdf5_group(f, "weight_names")
-    return [np.asarray(f[weight_name]) for weight_name in weight_names]
+    return [
+        np.asarray(h5_utils.safe_get_h5_dataset(f, weight_name))
+        for weight_name in weight_names
+    ]
 
 
 def load_weights_from_hdf5_group(f, model):
@@ -810,7 +817,7 @@ def load_weights_from_hdf5_group(f, model):
     layer_names = load_attributes_from_hdf5_group(f, "layer_names")
     filtered_layer_names = []
     for name in layer_names:
-        g = f[name]
+        g = h5_utils.safe_get_h5_group(f, name)
         weight_names = load_attributes_from_hdf5_group(g, "weight_names")
         if weight_names:
             filtered_layer_names.append(name)
@@ -826,7 +833,7 @@ def load_weights_from_hdf5_group(f, model):
     # which provides a speedup in TensorFlow.
     weight_value_tuples = []
     for k, name in enumerate(layer_names):
-        g = f[name]
+        g = h5_utils.safe_get_h5_group(f, name)
         layer = filtered_layers[k]
         symbolic_weights = _legacy_weights(layer)
         weight_values = load_subset_weights_from_hdf5_group(g)
@@ -847,7 +854,7 @@ def load_weights_from_hdf5_group(f, model):
             model._trainable_weights + model._non_trainable_weights
         )
         weight_values = load_subset_weights_from_hdf5_group(
-            f["top_level_model_weights"]
+            h5_utils.safe_get_h5_group(f, "top_level_model_weights")
         )
         if len(weight_values) != len(symbolic_weights):
             raise ValueError(
@@ -906,7 +913,7 @@ def load_weights_from_hdf5_group_by_name(f, model, skip_mismatch=False):
     # which provides a speedup in TensorFlow.
     weight_value_tuples = []
     for k, name in enumerate(layer_names):
-        g = f[name]
+        g = h5_utils.safe_get_h5_group(f, name)
         weight_values = load_subset_weights_from_hdf5_group(g)
         for layer in index.get(name, []):
             symbolic_weights = _legacy_weights(layer)
@@ -960,7 +967,7 @@ def load_weights_from_hdf5_group_by_name(f, model, skip_mismatch=False):
             model._trainable_weights + model._non_trainable_weights
         )
         weight_values = load_subset_weights_from_hdf5_group(
-            f["top_level_model_weights"]
+            h5_utils.safe_get_h5_group(f, "top_level_model_weights")
         )
 
         if len(weight_values) != len(symbolic_weights):

--- a/tf_keras/saving/legacy/save.py
+++ b/tf_keras/saving/legacy/save.py
@@ -19,6 +19,7 @@ import os
 import tensorflow.compat.v2 as tf
 
 from tf_keras import backend
+from tf_keras.saving import h5_utils
 from tf_keras.saving import object_registration
 from tf_keras.saving.legacy import hdf5_format
 from tf_keras.saving.legacy import saving_utils
@@ -484,7 +485,7 @@ def load_weights(
         model._assert_weights_created()
         with h5py.File(filepath, "r") as f:
             if "layer_names" not in f.attrs and "model_weights" in f:
-                f = f["model_weights"]
+                f = h5_utils.safe_get_h5_group(f, "model_weights")
             if by_name:
                 hdf5_format.load_weights_from_hdf5_group_by_name(
                     f, model, skip_mismatch

--- a/tf_keras/saving/legacy/save_weights_test.py
+++ b/tf_keras/saving/legacy/save_weights_test.py
@@ -433,6 +433,84 @@ class TestWeightSavingAndLoading(tf.test.TestCase, parameterized.TestCase):
             new_model.load_weights(save_path)
             self.assertAllClose(model.weights, new_model.weights)
 
+    def test_h5_weights_reject_external_storage_dataset(self):
+        # A .h5 model is untrusted data: a weight dataset stored externally
+        # would make loading read an attacker-named file off the host.
+        secret_path = os.path.join(self.get_temp_dir(), "secret.bin")
+        with open(secret_path, "wb") as f:
+            f.write(b"S" * 64)
+        save_path = os.path.join(self.get_temp_dir(), "malicious.h5")
+
+        model = keras.Sequential(
+            [keras.layers.Input((4,)), keras.layers.Dense(4, use_bias=False)]
+        )
+        model.save(save_path)
+
+        kernels = []
+
+        def collect_kernels(name, obj):
+            if isinstance(obj, h5py.Dataset) and name.endswith("kernel:0"):
+                kernels.append(name)
+
+        with h5py.File(save_path, "r") as f:
+            f.visititems(collect_kernels)
+        with h5py.File(save_path, "r+") as f:
+            shape, dtype = f[kernels[0]].shape, f[kernels[0]].dtype
+            del f[kernels[0]]
+            f.create_dataset(
+                kernels[0],
+                shape=shape,
+                dtype=dtype,
+                external=[(secret_path, 0, h5py.h5f.UNLIMITED)],
+            )
+
+        with self.assertRaisesRegex(ValueError, "external Dataset"):
+            keras.models.load_model(save_path)
+
+    def test_h5_optimizer_weights_reject_external_storage_dataset(self):
+        # Optimizer slots are restored from the same file and need the same
+        # guard as the layer weights.
+        secret_path = os.path.join(self.get_temp_dir(), "secret.bin")
+        with open(secret_path, "wb") as f:
+            f.write(b"S" * 64)
+        save_path = os.path.join(self.get_temp_dir(), "malicious_opt.h5")
+
+        model = keras.Sequential(
+            [keras.layers.Input((4,)), keras.layers.Dense(4, use_bias=False)]
+        )
+        model.compile(optimizer="adam", loss="mse")
+        model.fit(np.zeros((2, 4)), np.zeros((2, 4)), verbose=0)
+        model.save(save_path)
+
+        slots = []
+
+        def collect_slots(name, obj):
+            # HDF5 ignores external storage on scalar datasets, so only an
+            # array-shaped slot can carry the attack.
+            if (
+                isinstance(obj, h5py.Dataset)
+                and name.startswith("optimizer_weights/")
+                and obj.shape
+            ):
+                slots.append(name)
+
+        with h5py.File(save_path, "r") as f:
+            f.visititems(collect_slots)
+        if not slots:
+            self.skipTest("No array-shaped optimizer slot was saved.")
+        with h5py.File(save_path, "r+") as f:
+            shape, dtype = f[slots[0]].shape, f[slots[0]].dtype
+            del f[slots[0]]
+            f.create_dataset(
+                slots[0],
+                shape=shape,
+                dtype=dtype,
+                external=[(secret_path, 0, h5py.h5f.UNLIMITED)],
+            )
+
+        with self.assertRaisesRegex(ValueError, "external Dataset"):
+            keras.models.load_model(save_path)
+
 
 class SubclassedModel(training.Model):
     def __init__(self):

--- a/tf_keras/saving/saving_lib.py
+++ b/tf_keras/saving/saving_lib.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """Python-based idempotent model-saving functionality."""
 
+import collections.abc
 import datetime
 import io
 import json
@@ -30,6 +31,7 @@ import tf_keras as keras
 from tf_keras import losses
 from tf_keras.engine import base_layer
 from tf_keras.optimizers import optimizer
+from tf_keras.saving import h5_utils
 from tf_keras.saving.serialization_lib import ObjectSharingScope
 from tf_keras.saving.serialization_lib import deserialize_keras_object
 from tf_keras.saving.serialization_lib import serialize_keras_object
@@ -575,6 +577,28 @@ class DiskIOStore:
             tf.io.gfile.rmtree(self.tmp_dir)
 
 
+class H5Entry(collections.abc.Mapping):
+    """Read-only mapping of a trackable's saved variables.
+
+    Exposes the operations the variable store is documented to support, and
+    resolves every element through `h5_utils.safe_get_h5_dataset`, so a saved
+    model cannot point a variable at a file on the host or at a dataset whose
+    declared shape dwarfs what it actually stores.
+    """
+
+    def __init__(self, group):
+        self._group = group
+
+    def __getitem__(self, name):
+        return h5_utils.safe_get_h5_dataset(self._group, name)
+
+    def __iter__(self):
+        return iter(self._group)
+
+    def __len__(self):
+        return len(self._group)
+
+
 class H5IOStore:
     def __init__(self, root_path, archive=None, mode="r"):
         """Numerical variable store backed by HDF5.
@@ -605,11 +629,18 @@ class H5IOStore:
         return self.h5_file.create_group(path).create_group("vars")
 
     def get(self, path):
+        # A saved model is untrusted data, so variables are read through
+        # `H5Entry`, which rejects datasets that would read the host
+        # filesystem or force an unbounded allocation.
         if not path:
-            return self.h5_file["vars"]
-        if path in self.h5_file and "vars" in self.h5_file[path]:
-            return self.h5_file[path]["vars"]
-        return {}
+            return H5Entry(h5_utils.safe_get_h5_group(self.h5_file, "vars"))
+        try:
+            path_group = h5_utils.safe_get_h5_group(self.h5_file, path)
+            vars_group = h5_utils.safe_get_h5_group(path_group, "vars")
+        except KeyError:
+            # A trackable with no saved variables, as before.
+            return {}
+        return H5Entry(vars_group)
 
     def close(self):
         self.h5_file.close()

--- a/tf_keras/saving/saving_lib_test.py
+++ b/tf_keras/saving/saving_lib_test.py
@@ -908,6 +908,85 @@ class ComplexModel(keras.layers.Layer):
 
 
 @test_utils.run_v2_only
+class SavingV3SafetyTest(tf.test.TestCase):
+    def test_keras_weights_reject_external_storage_dataset(self):
+        # The .keras weights store is untrusted data too: an externally
+        # stored variable would make loading read a file off the host.
+        secret_path = os.path.join(self.get_temp_dir(), "secret.bin")
+        with open(secret_path, "wb") as f:
+            f.write(b"S" * 64)
+        good_path = os.path.join(self.get_temp_dir(), "good.keras")
+        bad_path = os.path.join(self.get_temp_dir(), "malicious.keras")
+        extracted = os.path.join(self.get_temp_dir(), "extracted")
+
+        model = keras.Sequential(
+            [keras.layers.Input((4,)), keras.layers.Dense(4, use_bias=False)]
+        )
+        model.save(good_path)
+
+        with zipfile.ZipFile(good_path) as archive:
+            archive.extractall(extracted)
+        weights_path = os.path.join(extracted, "model.weights.h5")
+        variables = []
+
+        def collect_variables(name, obj):
+            if isinstance(obj, h5py.Dataset) and name.endswith("/0"):
+                variables.append(name)
+
+        with h5py.File(weights_path, "r") as f:
+            f.visititems(collect_variables)
+        with h5py.File(weights_path, "r+") as f:
+            shape, dtype = f[variables[0]].shape, f[variables[0]].dtype
+            del f[variables[0]]
+            f.create_dataset(
+                variables[0],
+                shape=shape,
+                dtype=dtype,
+                external=[(secret_path, 0, h5py.h5f.UNLIMITED)],
+            )
+        with zipfile.ZipFile(bad_path, "w") as archive:
+            for root, _, files in os.walk(extracted):
+                for name in files:
+                    full = os.path.join(root, name)
+                    archive.write(full, os.path.relpath(full, extracted))
+
+        with self.assertRaisesRegex(ValueError, "external Dataset"):
+            saving_lib.load_model(bad_path)
+
+    def test_variable_store_rejects_dataset_where_group_is_expected(self):
+        # Looking up a trackable's variables must not dereference whatever the
+        # file put at that path: a Dataset there would be read before any
+        # check runs.
+        secret_path = os.path.join(self.get_temp_dir(), "secret.bin")
+        with open(secret_path, "wb") as f:
+            f.write(b"S" * 4096)
+        weights_path = os.path.join(self.get_temp_dir(), "weights.h5")
+        with h5py.File(weights_path, "w") as f:
+            f.create_group("layers").create_dataset(
+                "dense",
+                shape=(64, 8),
+                dtype="float64",
+                external=[(secret_path, 0, h5py.h5f.UNLIMITED)],
+            )
+
+        reads = []
+        original_iter = h5py.Dataset.__iter__
+
+        def counting_iter(self):
+            reads.append(1)
+            return original_iter(self)
+
+        h5py.Dataset.__iter__ = counting_iter
+        try:
+            store = saving_lib.H5IOStore(weights_path, mode="r")
+            with self.assertRaisesRegex(ValueError, "expected Group"):
+                store.get("layers/dense")
+        finally:
+            h5py.Dataset.__iter__ = original_iter
+        self.assertEmpty(reads)
+
+
+@test_utils.run_v2_only
 class SavingV3BattleTest(tf.test.TestCase, parameterized.TestCase):
     def test_custom_model_without_registration_error(self):
         temp_filepath = os.path.join(


### PR DESCRIPTION
### What

Backports the `safe_get_h5_dataset` / `safe_get_h5_group` guards that Keras 3 added for CVE-2026-1669, and routes the TF-Keras HDF5 load paths through them.

### Why

A saved model is untrusted data, but the HDF5 loaders read every weight dataset straight out of the file. HDF5 lets a dataset keep its bytes in a separate file (external storage), resolve through an external or soft link, or map from other files (a virtual dataset) — none of which a weights file has any reason to use. So loading a crafted `.h5` or `.keras` file reads an attacker-named path off the host and hands the bytes back as weights. Separately, a dataset can declare a shape far larger than it stores, turning a small file into a huge allocation.

Keras 3 fixed this in `keras/src/saving/saving_lib.py`. TF-Keras has the same load paths and none of the guards.

### What changed

- **New `tf_keras/saving/h5_utils.py`** — `safe_get_h5_group` and `safe_get_h5_dataset`, mirroring Keras 3. They reject external/soft links, external storage, virtual datasets, and datasets whose declared in-memory size dwarfs what is stored on disk (over 4 GiB declared *and* over 1000× the stored bytes; dense weights written by TF-Keras stay well inside that).
- **`tf_keras/saving/legacy/hdf5_format.py`** — layer weights, optimizer weights and top-level model weights on the legacy `.h5` path now resolve through the guarded accessors.
- **`tf_keras/saving/legacy/save.py`** — same for the `model_weights` group in `load_weights()`.
- **`tf_keras/saving/saving_lib.py`** — `H5IOStore.get()` returns an `H5Entry` read-only mapping instead of the raw group, so the `.keras` weights store resolves each variable through `safe_get_h5_dataset`. `load_own_variables()` implementations keep the same mapping interface (`store["0"]`, `len(store)`, iteration), and a trackable with no saved variables still gets `{}`.

### Tests

- `tf_keras/saving/h5_utils_test.py` — unit tests for both accessors.
- `save_weights_test.py` / `saving_lib_test.py` — end-to-end: a model whose layer or optimizer weights use an external dataset fails to load, for both the `.h5` and `.keras` formats.
- I ran the whole `tf_keras/saving/` suite on master and on this branch: identical set of pre-existing failures in my environment, and 13 more tests passing from this change. `isort`, `flake8` and `black --line-length 80` (the versions pinned in `shell/lint.sh`'s workflow) are clean on the changed files.

This was reported through the Google Bug Hunters program; I am opening the PR with their go-ahead.
